### PR TITLE
Potential fix for code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1893,7 +1893,8 @@ class AkashicEditor {
             }
         } catch (err) {
             console.error('Generation failed:', err);
-            aiMsgDiv.innerHTML = `<div class="ai-message-content" style="color: var(--error-color);">Error: ${err.message}</div>`;
+            const safeErrorMessage = this.escapeHtml(err && err.message ? String(err.message) : String(err));
+            aiMsgDiv.innerHTML = `<div class="ai-message-content" style="color: var(--error-color);">Error: ${safeErrorMessage}</div>`;
         }
         
         // Scroll to bottom again


### PR DESCRIPTION
Potential fix for [https://github.com/Aswanidev-vs/Akashic/security/code-scanning/1](https://github.com/Aswanidev-vs/Akashic/security/code-scanning/1)

In general, the fix is to ensure that any exception text or user‑influenced string that is written into the DOM is properly escaped for the HTML context, or is assigned via `textContent` instead of `innerHTML`. Here, we already have a helper `escapeHtml(text)` used for other user‑controlled strings. The best fix is to apply that same escaping to `err.message` before writing it into `aiMsgDiv.innerHTML`.

Concretely, in `frontend/src/main.js`, inside `generateWithAI()`, in the `catch (err)` block around line 1894, replace:

```js
aiMsgDiv.innerHTML = `<div class="ai-message-content" style="color: var(--error-color);">Error: ${err.message}</div>`;
```

with a version that escapes the error message:

```js
const safeErrorMessage = this.escapeHtml(err && err.message ? String(err.message) : String(err));
aiMsgDiv.innerHTML = `<div class="ai-message-content" style="color: var(--error-color);">Error: ${safeErrorMessage}</div>`;
```

This keeps the same visible behavior (showing `Error: <message>`), but ensures any special characters from user input or from the exception cannot break out of the surrounding HTML. No new imports or additional files are required; we reuse the existing `escapeHtml` method defined in the same file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
