### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -772,6 +772,11 @@ class AkashicEditor {
         // Format current block as heading or paragraph
         const selection = window.getSelection();
         if (selection.rangeCount === 0) return;
+
+        // Allow only expected block tags from the heading control.
+        const allowedTags = new Set(['p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+        const normalizedTagName = typeof tagName === 'string' ? tagName.toLowerCase() : '';
+        const safeTagName = allowedTags.has(normalizedTagName) ? normalizedTagName : 'p';
         
         const range = selection.getRangeAt(0);
         let node = range.commonAncestorContainer;
@@ -783,12 +788,12 @@ class AkashicEditor {
         
         if (!node || node === document.body) {
             // No block found, use formatBlock command
-            document.execCommand('formatBlock', false, tagName);
+            document.execCommand('formatBlock', false, safeTagName);
             return;
         }
         
         // Create new element
-        const newElement = document.createElement(tagName);
+        const newElement = document.createElement(safeTagName);
         
         // Copy content
         newElement.innerHTML = node.innerHTML;


### PR DESCRIPTION
Potential fix for [https://github.com/Aswanidev-vs/Akashic/security/code-scanning/3](https://github.com/Aswanidev-vs/Akashic/security/code-scanning/3)

General fix: never use untrusted input directly as a tag name; enforce a strict allowlist of permitted tags before calling `document.createElement`.

Best fix here: in `frontend/src/main.js`, inside `formatBlock(tagName)`, normalize and validate `tagName` against a fixed set (e.g., `p`, `h1`–`h6`, `div`). If invalid, safely fall back to `'p'` (or return). Then use only the validated value for both `execCommand('formatBlock', ...)` and `createElement(...)`. This preserves existing behavior for legitimate heading choices while blocking unsafe values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content formatting reliability by validating block types.
  * Unsupported formatting options now safely default to paragraph blocks.
  * Consistent formatting is applied when creating or updating content blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->